### PR TITLE
chore: simplify config declaration by only accepting inline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
 # Coraza WASM filter
+
+Web Application Firewall WASM filter built on top of Coraza and implementing on proxy-wasm ABI. It can be loaded directlu from Envoy or also used as an istio plugin.
+
+## Getting started
+
+In order to run the coraza-wasm-filter we need to spin up an envoy configuration including this the filter config:
+
+```yaml
+    ...
+
+    filter_chains:
+    - filters:
+        - name: envoy.filters.network.http_connection_manager
+            typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            stat_prefix: ingress_http
+            codec_type: auto
+            route_config:
+                ...
+            http_filters:
+                - name: envoy.filters.http.wasm
+                typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+                    config:
+                    name: "coraza-filter"
+                    root_id: ""
+                    configuration:
+                        "@type": "type.googleapis.com/google.protobuf.StringValue"
+                        value: |
+                        {
+                            "rules": "SecDebugLogLevel 5 \nSecRuleEngine On \nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""
+                        }
+                    vm_config:
+                        runtime: "envoy.wasm.runtime.v8"
+                        vm_id: "coraza-filter_vm_id"
+                        code:
+                        local:
+                            filename: "build/main.wasm"
+```
+
+### Using CRS
+
+Coreruleset comes embeded in the extension, in order to use it in the config, you just need to include it directly in the rules:
+
+Loading entire coreruleset:
+
+```yaml
+configuration:
+    "@type": "type.googleapis.com/google.protobuf.StringValue"
+    value: |
+    {
+        "rules": "SecDebugLogLevel 5 \nSecRuleEngine On \n Include crs/*.conf"
+    }
+```
+
+Loading some pieces:
+
+```yaml
+configuration:
+    "@type": "type.googleapis.com/google.protobuf.StringValue"
+    value: |
+    {
+        "rules": "SecDebugLogLevel 5 \nSecRuleEngine On \n Include crs/REQUEST-901-INITIALIZATION.conf"
+    }
+```

--- a/config.go
+++ b/config.go
@@ -5,23 +5,14 @@ package main
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
-	"io"
-	"io/fs"
-	"strings"
 
 	"github.com/tidwall/gjson"
 )
 
-type rule struct {
-	inline  string
-	include string
-}
-
 // pluginConfiguration is a type to represent an example configuration for this wasm plugin.
 type pluginConfiguration struct {
-	rules []rule
+	rules string
 }
 
 func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
@@ -38,89 +29,7 @@ func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
 
 	jsonData := gjson.ParseBytes(data)
 	rules := jsonData.Get("rules")
-	rules.ForEach(func(_, value gjson.Result) bool {
-		if inline := value.Get("inline"); inline.Exists() {
-			config.rules = append(config.rules, rule{inline: inline.String()})
-			return true
-		} else if include := value.Get("include"); include.Exists() {
-			config.rules = append(config.rules, rule{include: include.String()})
-			return true
-		} else {
-			return false
-		}
-	})
+	config.rules = rules.String()
 
 	return config, nil
-}
-
-func resolveIncludes(rs []rule, crsRules fs.FS) (string, error) {
-	if len(rs) == 0 {
-		return "", nil
-	}
-
-	srs := strings.Builder{}
-	defer srs.Reset()
-	for _, r := range rs {
-		switch {
-		case r.inline != "":
-			srs.WriteString(strings.TrimSpace(r.inline))
-
-		case r.include != "":
-			if r.include == "OWASP_CRS" {
-				ors := strings.Builder{}
-
-				err := fs.WalkDir(crsRules, ".", func(path string, d fs.DirEntry, err error) error {
-					if err != nil {
-						return err
-					}
-
-					if d.IsDir() {
-						return nil
-					}
-
-					if !strings.HasPrefix(path, "REQUEST-") && !strings.HasPrefix(path, "RESPONSE-") {
-						return nil
-					}
-
-					f, err := crsRules.Open(path)
-					if err != nil {
-						return fmt.Errorf("failed to open embedded rule %q: %s", path, err.Error())
-					}
-
-					fc, err := io.ReadAll(f)
-					f.Close()
-					if err != nil {
-						return fmt.Errorf("failed to read embedded rule file %q: %s", path, err.Error())
-					}
-
-					_, err = ors.Write(bytes.TrimSpace(fc))
-					return err
-				})
-				if err != nil {
-					return "", fmt.Errorf("failed to walk embedded rules: %s", err.Error())
-				}
-
-				owaspCRSContent := strings.TrimSpace(ors.String())
-				ors.Reset()
-				srs.WriteString(owaspCRSContent)
-			} else {
-				f, err := crsRules.Open(r.include[len("OWASP_CRS_"):] + ".conf")
-				if err != nil {
-					return "", fmt.Errorf("failed to open embedded rule %q: %s", r.include, err.Error())
-				}
-				content, err := io.ReadAll(f)
-				f.Close()
-				if err != nil {
-					return "", fmt.Errorf("failed to read embedded rule file: %s", err.Error())
-				}
-				content = bytes.TrimSpace(content)
-				srs.Write(content)
-			}
-		default:
-			return "", errors.New("empty rule")
-		}
-		srs.WriteString("\n")
-	}
-
-	return strings.TrimSpace(srs.String()), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -265,7 +265,7 @@ SecRuleEngine On\nSecResponseBodyAccess On\nSecRule RESPONSE_BODY \"@contains he
 				if inlineRules := strings.TrimSpace(tt.inlineRules); inlineRules != "" {
 					conf = fmt.Sprintf(`
 					{ 
-						"rules": [ { "inline": "%s" } ]
+						"rules": "%s"
 					}	
 				`, inlineRules)
 				}
@@ -557,7 +557,7 @@ func TestLogError(t *testing.T) {
 			t.Run(fmt.Sprintf("severity %d", tt.severity), func(t *testing.T) {
 				conf := fmt.Sprintf(`
 {
-	"rules" : [{"inline": "SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:%d,msg:'%%{MATCHED_VAR}',pass,t:none\""}]
+	"rules" : "SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:%d,msg:'%%{MATCHED_VAR}',pass,t:none\""
 }
 `, tt.severity)
 
@@ -587,7 +587,7 @@ func TestParseCRS(t *testing.T) {
 		opt := proxytest.
 			NewEmulatorOption().
 			WithVMContext(vm).
-			WithPluginConfiguration([]byte(`{ "rules": [ {"inline": "Include ftw-config.conf\nInclude coraza.conf-recommended\nInclude crs-setup.conf.example\nInclude crs/*.conf"} ] }`))
+			WithPluginConfiguration([]byte(`{ "rules": "Include ftw-config.conf\nInclude coraza.conf-recommended\nInclude crs-setup.conf.example\nInclude crs/*.conf" }`))
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()
@@ -657,7 +657,7 @@ SecRuleEngine On\nSecRule REQUEST_URI \"@streq /hello\" \"id:101,phase:4,t:lower
 
 			t.Run(tt.name, func(t *testing.T) {
 				conf := fmt.Sprintf(`
-					{ "rules": [ {"inline": "%s"} ] }
+					{ "rules": "%s" }
 				`, strings.TrimSpace(tt.rules))
 				opt := proxytest.
 					NewEmulatorOption().

--- a/testdata/fake_crs/REQUEST-911.conf
+++ b/testdata/fake_crs/REQUEST-911.conf
@@ -1,1 +1,0 @@
-# just a comment


### PR DESCRIPTION
Before we supported both inline and include directives, however with the usage of fs.FS in coraza for setting the root, it is possible to load rules transparently, hence we can ease the UX by including CRS directly.